### PR TITLE
Fix GitHub Actions artifact deprecation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,7 +28,7 @@ jobs:
       - run: |
           mkdir -p build
           touch build/.nojekyll
-      - uses: actions/upload-pages-artifact@v1
+      - uses: actions/upload-pages-artifact@v3
         with:
           path: './build'
   deploy:


### PR DESCRIPTION
## Summary
- update workflow to use `actions/upload-pages-artifact@v3`

## Testing
- `npm run lint` in `frontend`

------
https://chatgpt.com/codex/tasks/task_e_6871085f8f6083259e5fc7bed35d8804