### PR TITLE
Add journeys screens with journaling

### DIFF
--- a/cms/spreads/career.ts
+++ b/cms/spreads/career.ts
@@ -1,0 +1,17 @@
+export default {
+  name: 'Career',
+  cards: [
+    {
+      prompt: 'What strengths can I leverage in my career?',
+      instruction: 'Card 1 – identify your assets.'
+    },
+    {
+      prompt: 'What obstacles do I face professionally?',
+      instruction: 'Card 2 – acknowledge blocks.'
+    },
+    {
+      prompt: 'What next steps should I take to grow?',
+      instruction: 'Card 3 – path forward.'
+    }
+  ]
+};

--- a/cms/spreads/index.ts
+++ b/cms/spreads/index.ts
@@ -1,0 +1,2 @@
+export { default as relationships } from './relationships';
+export { default as career } from './career';

--- a/cms/spreads/relationships.ts
+++ b/cms/spreads/relationships.ts
@@ -1,0 +1,17 @@
+export default {
+  name: 'Relationships',
+  cards: [
+    {
+      prompt: 'What do I value most in a partnership?',
+      instruction: 'Card 1 – examine core values.'
+    },
+    {
+      prompt: 'Where do I feel challenged in relationships?',
+      instruction: 'Card 2 – explore obstacles.'
+    },
+    {
+      prompt: 'How can I invite more love into my life?',
+      instruction: 'Card 3 – guidance forward.'
+    }
+  ]
+};

--- a/frontend/app/(tabs)/_layout.tsx
+++ b/frontend/app/(tabs)/_layout.tsx
@@ -40,6 +40,13 @@ export default function TabLayout() {
           tabBarIcon: ({ color }) => <IconSymbol size={28} name="paperplane.fill" color={color} />,
         }}
       />
+      <Tabs.Screen
+        name="journeys"
+        options={{
+          title: 'Journeys',
+          tabBarIcon: ({ color }) => <IconSymbol size={28} name="sparkles" color={color} />,
+        }}
+      />
     </Tabs>
   );
 }

--- a/frontend/app/journeys/career.tsx
+++ b/frontend/app/journeys/career.tsx
@@ -1,0 +1,6 @@
+import SpreadJourney from '@/components/SpreadJourney';
+import career from '../../../cms/spreads/career';
+
+export default function CareerJourney() {
+  return <SpreadJourney spread={career} slug="career" />;
+}

--- a/frontend/app/journeys/index.tsx
+++ b/frontend/app/journeys/index.tsx
@@ -1,0 +1,20 @@
+import { Link } from 'expo-router';
+import { ThemedView } from '@/components/ThemedView';
+import { ThemedText } from '@/components/ThemedText';
+import * as spreads from '../../../cms/spreads';
+
+export default function Journeys() {
+  return (
+    <ThemedView style={{ padding: 20, gap: 12 }}>
+      <ThemedText type="title">Journeys</ThemedText>
+      {Object.entries(spreads).map(([key, spread]) => (
+        <Link
+          key={key}
+          href={`/journeys/${key}`}
+          style={{ paddingVertical: 8 }}>
+          <ThemedText type="subtitle">{spread.name}</ThemedText>
+        </Link>
+      ))}
+    </ThemedView>
+  );
+}

--- a/frontend/app/journeys/relationships.tsx
+++ b/frontend/app/journeys/relationships.tsx
@@ -1,0 +1,6 @@
+import SpreadJourney from '@/components/SpreadJourney';
+import relationships from '../../../cms/spreads/relationships';
+
+export default function RelationshipsJourney() {
+  return <SpreadJourney spread={relationships} slug="relationships" />;
+}

--- a/frontend/components/SpreadJourney.tsx
+++ b/frontend/components/SpreadJourney.tsx
@@ -1,0 +1,66 @@
+import { useState } from 'react';
+import { TextInput, Button, StyleSheet } from 'react-native';
+import { useRouter } from 'expo-router';
+import { ThemedText } from '@/components/ThemedText';
+import { ThemedView } from '@/components/ThemedView';
+import { addReflection } from '@/utils/journal';
+
+export interface CardStep {
+  prompt: string;
+  instruction: string;
+}
+
+export interface SpreadData {
+  name: string;
+  cards: CardStep[];
+}
+
+export default function SpreadJourney({ spread, slug }: { spread: SpreadData; slug: string }) {
+  const [step, setStep] = useState(0);
+  const [text, setText] = useState('');
+  const router = useRouter();
+
+  const card = spread.cards[step];
+  const isLast = step === spread.cards.length - 1;
+
+  async function next() {
+    await addReflection({ spread: slug, cardIndex: step, text });
+    setText('');
+    if (isLast) {
+      router.back();
+    } else {
+      setStep(step + 1);
+    }
+  }
+
+  return (
+    <ThemedView style={styles.container}>
+      <ThemedText type="title">{spread.name}</ThemedText>
+      <ThemedText type="subtitle">Card {step + 1}</ThemedText>
+      <ThemedText>{card.instruction}</ThemedText>
+      <ThemedText>{card.prompt}</ThemedText>
+      <TextInput
+        placeholder="Your reflection..."
+        value={text}
+        onChangeText={setText}
+        style={styles.input}
+        multiline
+      />
+      <Button title={isLast ? 'Finish' : 'Next'} onPress={next} />
+    </ThemedView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 20,
+    gap: 12,
+  },
+  input: {
+    borderWidth: 1,
+    padding: 8,
+    borderRadius: 4,
+    minHeight: 80,
+  },
+});

--- a/frontend/components/ThemedView.tsx
+++ b/frontend/components/ThemedView.tsx
@@ -3,13 +3,12 @@ import { ImageBackground, type ViewProps } from 'react-native';
 import { useColorScheme } from '@/hooks/useColorScheme';
 
 import { useThemeColor } from '@/hooks/useThemeColor';
+import { starryDark, starryLight } from '../assets/imageData';
 
 export type ThemedViewProps = ViewProps & {
   lightColor?: string;
   darkColor?: string;
 };
-
-import { starryDark, starryLight } from '../assets/imageData';
 
 const textures = {
   light: { uri: starryLight },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@expo/vector-icons": "^14.1.0",
+        "@react-native-async-storage/async-storage": "^2.2.0",
         "@react-navigation/bottom-tabs": "^7.3.10",
         "@react-navigation/elements": "^2.3.8",
         "@react-navigation/native": "^7.1.6",
@@ -2755,6 +2756,18 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@react-native-async-storage/async-storage": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-2.2.0.tgz",
+      "integrity": "sha512-gvRvjR5JAaUZF8tv2Kcq/Gbt3JHwbKFYfmb445rhOj6NUMx3qPLixmDx5pZAyb9at1bYvJ4/eTUipU5aki45xw==",
+      "license": "MIT",
+      "dependencies": {
+        "merge-options": "^3.0.4"
+      },
+      "peerDependencies": {
+        "react-native": "^0.0.0-0 || >=0.65 <1.0"
       }
     },
     "node_modules/@react-native/assets-registry": {
@@ -7666,6 +7679,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -8675,6 +8697,18 @@
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
       "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
       "license": "MIT"
+    },
+    "node_modules/merge-options": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
+      "integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@expo/vector-icons": "^14.1.0",
+    "@react-native-async-storage/async-storage": "^2.2.0",
     "@react-navigation/bottom-tabs": "^7.3.10",
     "@react-navigation/elements": "^2.3.8",
     "@react-navigation/native": "^7.1.6",

--- a/frontend/utils/journal.ts
+++ b/frontend/utils/journal.ts
@@ -1,0 +1,22 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+export interface ReflectionEntry {
+  date: string;
+  spread: string;
+  cardIndex: number;
+  text: string;
+}
+
+const STORAGE_KEY = 'journalEntries';
+
+export async function addReflection(entry: Omit<ReflectionEntry, 'date'>) {
+  const existing = await AsyncStorage.getItem(STORAGE_KEY);
+  const data: ReflectionEntry[] = existing ? JSON.parse(existing) : [];
+  data.push({ ...entry, date: new Date().toISOString() });
+  await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+}
+
+export async function getJournal(): Promise<ReflectionEntry[]> {
+  const existing = await AsyncStorage.getItem(STORAGE_KEY);
+  return existing ? JSON.parse(existing) : [];
+}


### PR DESCRIPTION
## Summary
- add cms spreads for Relationships and Career
- implement journaling via AsyncStorage
- create SpreadJourney component for prompt walkthrough
- add journeys screens and tab entry

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68710ebff9748325b290c35699b671cb