### PR TITLE
Implement astrology hook and daily card

### DIFF
--- a/frontend/app/(tabs)/_layout.tsx
+++ b/frontend/app/(tabs)/_layout.tsx
@@ -30,7 +30,14 @@ export default function TabLayout() {
         name="index"
         options={{
           title: 'Home',
-          tabBarIcon: ({ color }) => <IconSymbol size={28} name="house.fill" color={color} />,
+          tabBarIcon: ({ color }) => <IconSymbol size={28} name="house.fill" color={color} />, 
+        }}
+      />
+      <Tabs.Screen
+        name="daily"
+        options={{
+          title: 'Daily',
+          tabBarIcon: ({ color }) => <IconSymbol size={28} name="moon.fill" color={color} />,
         }}
       />
       <Tabs.Screen

--- a/frontend/app/(tabs)/daily.tsx
+++ b/frontend/app/(tabs)/daily.tsx
@@ -1,0 +1,28 @@
+import { StyleSheet, View } from 'react-native';
+import { ThemedText } from '@/components/ThemedText';
+import { ThemedView } from '@/components/ThemedView';
+import { useAstrology } from '@/hooks/useAstrology';
+
+export default function DailyCardScreen() {
+  const today = new Date();
+  const { phase, data, loading, error } = useAstrology(today);
+
+  return (
+    <ThemedView style={styles.container}>
+      <ThemedText type="title">Daily Card</ThemedText>
+      <ThemedText>Moon Phase: {phase}</ThemedText>
+      {loading && <ThemedText>Loading astrology...</ThemedText>}
+      {error && <ThemedText>Failed to load data</ThemedText>}
+      {data?.insights && <ThemedText>{data.insights}</ThemedText>}
+    </ThemedView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    gap: 12,
+  },
+});

--- a/frontend/components/ui/IconSymbol.tsx
+++ b/frontend/components/ui/IconSymbol.tsx
@@ -18,6 +18,7 @@ const MAPPING = {
   'paperplane.fill': 'send',
   'chevron.left.forwardslash.chevron.right': 'code',
   'chevron.right': 'chevron-right',
+  'moon.fill': 'dark-mode',
 } as IconMapping;
 
 /**

--- a/frontend/hooks/useAstrology.ts
+++ b/frontend/hooks/useAstrology.ts
@@ -1,0 +1,84 @@
+import { useEffect, useMemo, useState } from 'react';
+import * as Notifications from 'expo-notifications';
+
+export interface AstrologyEvent {
+  title: string;
+  date: string;
+  reminder?: boolean;
+}
+
+export interface AstrologyData {
+  insights?: string;
+  events?: AstrologyEvent[];
+}
+
+function getMoonPhase(date: Date): string {
+  const synodicMonth = 29.530588853;
+  const knownNewMoon = Date.UTC(2000, 0, 6, 18, 14); // 2000-01-06
+  const daysSince = (date.getTime() - knownNewMoon) / 86400000;
+  let phase = (daysSince % synodicMonth) / synodicMonth;
+  if (phase < 0) phase += 1;
+  if (phase < 0.03 || phase > 0.97) return 'New Moon';
+  if (phase < 0.22) return 'Waxing Crescent';
+  if (phase < 0.28) return 'First Quarter';
+  if (phase < 0.47) return 'Waxing Gibbous';
+  if (phase < 0.53) return 'Full Moon';
+  if (phase < 0.72) return 'Waning Gibbous';
+  if (phase < 0.78) return 'Last Quarter';
+  return 'Waning Crescent';
+}
+
+async function scheduleReminders(events: AstrologyEvent[]) {
+  const existing = await Notifications.getPermissionsAsync();
+  if (existing.status !== 'granted') {
+    await Notifications.requestPermissionsAsync();
+  }
+  await Promise.all(
+    events
+      .filter((e) => e.reminder)
+      .map(async (e) => {
+        const trigger = new Date(e.date);
+        if (trigger > new Date()) {
+          await Notifications.scheduleNotificationAsync({
+            content: { title: e.title, body: 'Astrological event today' },
+            trigger,
+          });
+        }
+      })
+  );
+}
+
+export function useAstrology(date: Date) {
+  const [data, setData] = useState<AstrologyData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  const phase = useMemo(() => getMoonPhase(date), [date]);
+
+  useEffect(() => {
+    let isMounted = true;
+    async function fetchData() {
+      try {
+        setLoading(true);
+        const response = await fetch(`/api/astrology?date=${date.toISOString().split('T')[0]}`);
+        if (!response.ok) throw new Error('Failed to fetch astrology data');
+        const json: AstrologyData = await response.json();
+        if (!isMounted) return;
+        setData(json);
+        if (json.events) {
+          scheduleReminders(json.events).catch(() => {});
+        }
+      } catch (err) {
+        if (isMounted) setError(err as Error);
+      } finally {
+        if (isMounted) setLoading(false);
+      }
+    }
+    fetchData();
+    return () => {
+      isMounted = false;
+    };
+  }, [date]);
+
+  return { phase, data, loading, error };
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,6 +28,7 @@
     "expo-symbols": "~0.4.5",
     "expo-system-ui": "~5.0.10",
     "expo-web-browser": "~14.2.0",
+    "expo-notifications": "~0.21.0",
     "lottie-react-native": "^6.7.2",
     "react": "19.0.0",
     "react-dom": "19.0.0",


### PR DESCRIPTION
## Summary
- add moon phase & astrology fetch hook
- display insights on a new Daily Card tab
- map a moon icon in `IconSymbol`
- expose Daily tab in navigator
- include expo-notifications dependency

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_68710ec6ef188325a00943e8e5912cc4